### PR TITLE
Ignore restart on a given rollout or deployment

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"github.com/keikoproj/flippy/pkg/common"
 	"os"
 	"time"
 
@@ -61,6 +62,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.DurationVar(&flagReconcilerTime, "reconciler-time", 10*time.Hour, "The flippy reconciler time.")
+	flag.StringVar(&common.IgnoreMetadata, "ignore-metadata", "flippy-ignore", "Annotation (Rollout/Deployment) and Label (Namespace) to be ignored")
 
 	opts := zap.Options{
 		Development: true,

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.DurationVar(&flagReconcilerTime, "reconciler-time", 10*time.Hour, "The flippy reconciler time.")
-	flag.StringVar(&common.IgnoreMetadata, "ignore-metadata", "flippy-ignore", "Annotation (Rollout/Deployment) and Label (Namespace) to be ignored")
+	flag.StringVar(&common.IgnoreMetadataKey, "flippy-ignore-key", "flippy-ignore", "Annotation (Rollout/Deployment) and Label (Namespace) to be ignored")
 
 	opts := zap.Options{
 		Development: true,

--- a/pkg/common/Constants.go
+++ b/pkg/common/Constants.go
@@ -23,3 +23,5 @@ type RestartObjects struct {
 	NamespaceObjects map[string][]string
 	RestartConfig    crdv1.StatusCheckConfig
 }
+
+var IgnoreMetadata string

--- a/pkg/common/Constants.go
+++ b/pkg/common/Constants.go
@@ -24,4 +24,4 @@ type RestartObjects struct {
 	RestartConfig    crdv1.StatusCheckConfig
 }
 
-var IgnoreMetadata string
+var IgnoreMetadataKey string

--- a/pkg/k8s-utils/utils/utils.go
+++ b/pkg/k8s-utils/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/argoproj/argo-rollouts/pkg/client/clientset/versioned"
 	"github.com/keikoproj/flippy/pkg/common"
@@ -73,6 +74,12 @@ func StringArrayContains(s []string, str string) bool {
 }
 
 func IsStringMapSubset(masterMap map[string]string, subsetMap map[string]string) bool {
+	flippyIgnore, ok := masterMap[common.IgnoreMetadata]
+
+	if ok && strings.ToLower(flippyIgnore) == "true" {
+		return false
+	}
+
 	match := 0
 	for key, value := range subsetMap {
 		masterValue, ok := masterMap[key]

--- a/pkg/k8s-utils/utils/utils.go
+++ b/pkg/k8s-utils/utils/utils.go
@@ -74,7 +74,7 @@ func StringArrayContains(s []string, str string) bool {
 }
 
 func IsStringMapSubset(masterMap map[string]string, subsetMap map[string]string) bool {
-	flippyIgnore, ok := masterMap[common.IgnoreMetadata]
+	flippyIgnore, ok := masterMap[common.IgnoreMetadataKey]
 
 	if ok && strings.ToLower(flippyIgnore) == "true" {
 		return false

--- a/pkg/k8s-utils/utils/utils_test.go
+++ b/pkg/k8s-utils/utils/utils_test.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"github.com/keikoproj/flippy/pkg/common"
+	"testing"
+)
+
+func TestIsStringMapSubset(t *testing.T) {
+
+	masterMap := make(map[string]string)
+	masterMap["test1"] = "test"
+	masterMap["test2"] = ""
+	masterMap["test3"] = "true"
+	masterMap["test4"] = "false"
+
+	subsetMap := make(map[string]string)
+	subsetMap["test1"] = "test"
+
+	tests := []struct {
+		name string
+		args string
+		want bool
+	}{
+		{"No addition to label", "empty", true},
+		{"Addition to label to ignore flippy with empty value", "test2", true},
+		{"Addition to label to ignore flippy", "test3", false},
+		{"Addition to label to ignore flippy with default value", "test4", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args != "empty" {
+				common.IgnoreMetadata = tt.args
+			}
+			if got := IsStringMapSubset(masterMap, subsetMap); got != tt.want {
+				t.Errorf("IsStringMapSubset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/k8s-utils/utils/utils_test.go
+++ b/pkg/k8s-utils/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"github.com/keikoproj/flippy/pkg/common"
+	"github.com/tj/assert"
 	"testing"
 )
 
@@ -36,4 +37,19 @@ func TestIsStringMapSubset(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsStringMapSubsetNegative(t *testing.T) {
+
+	masterMap := make(map[string]string)
+	masterMap["test1"] = "test"
+	masterMap["test2"] = ""
+	masterMap["test3"] = "true"
+	masterMap["test4"] = "false"
+
+	subsetMap := make(map[string]string)
+	subsetMap["test5"] = "test"
+
+	got := IsStringMapSubset(masterMap, subsetMap)
+	assert.Equal(t, false, got)
 }

--- a/pkg/k8s-utils/utils/utils_test.go
+++ b/pkg/k8s-utils/utils/utils_test.go
@@ -29,7 +29,7 @@ func TestIsStringMapSubset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.args != "empty" {
-				common.IgnoreMetadata = tt.args
+				common.IgnoreMetadataKey = tt.args
 			}
 			if got := IsStringMapSubset(masterMap, subsetMap); got != tt.want {
 				t.Errorf("IsStringMapSubset() = %v, want %v", got, tt.want)


### PR DESCRIPTION
**Is this a FEATURE REQUEST?**:

**What happened**:
We are adding a filter. If it is present on rollout/deployment/namespace then flippy should not rotate given object

**What you expected to happen**:
If parameter is provided then 
- If annotation is present for rollout/deployment then that object is removed from rotation
- If label is present for namespace then that namespace is removed from rotation

**How to reproduce it (as minimally and precisely as possible)**:
N/A

**Environment**:
N/A