### PR TITLE
fix docker alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.19 as builder
+FROM golang:1.24-alpine3.21 AS builder
 
 USER root
 


### PR DESCRIPTION
Previous commit had a deprecated go-alpine combination